### PR TITLE
Aops

### DIFF
--- a/cms/package.json
+++ b/cms/package.json
@@ -15,6 +15,7 @@
   ],
   "dependencies": {
     "@sanity/base": "^2.35.2",
+    "@sanity/code-input": "^2.30.0",
     "@sanity/core": "^2.35.0",
     "@sanity/default-layout": "^2.35.2",
     "@sanity/default-login": "^2.35.2",

--- a/cms/sanity.json
+++ b/cms/sanity.json
@@ -18,9 +18,7 @@
   ],
   "env": {
     "development": {
-      "plugins": [
-        "@sanity/vision"
-      ]
+      "plugins": ["@sanity/vision", "@sanity/code-input"]
     }
   },
   "parts": [

--- a/cms/schemas/documents/companyInfo.js
+++ b/cms/schemas/documents/companyInfo.js
@@ -41,5 +41,13 @@ export default {
       title: 'Maps Link',
       type: 'url',
     },
+    {
+      name: 'mapsEmbed',
+      title: 'Maps Embed',
+      type: 'code',
+      options: {
+        language: 'html',
+      },
+    },
   ],
 }

--- a/cms/schemas/documents/companyInfo.js
+++ b/cms/schemas/documents/companyInfo.js
@@ -12,6 +12,7 @@ export default {
       name: 'name',
       title: 'Name',
       type: 'string',
+      codegen: { required: true },
       validation: (Rule) => Rule.required(),
     },
     {

--- a/cms/schemas/documents/homePage.js
+++ b/cms/schemas/documents/homePage.js
@@ -2,7 +2,7 @@ export default {
   name: 'homePage',
   title: 'Home Page',
   type: 'document',
-  __experimental_actions: [/*"create"*/ 'update', /*'delete',*/ 'publish'],
+  __experimental_actions: ['create', 'update', /*'delete',*/ 'publish'],
   groups: [
     {
       title: 'Hero',
@@ -11,6 +11,10 @@ export default {
     {
       title: 'Company History',
       name: 'companyHistory',
+    },
+    {
+      title: 'Services',
+      name: 'services',
     },
   ],
   fields: [
@@ -32,6 +36,12 @@ export default {
       title: 'Company History',
       type: 'companyHistory',
       group: 'companyHistory',
+    },
+    {
+      name: 'services',
+      title: 'Services',
+      type: 'services',
+      group: 'services',
     },
   ],
 }

--- a/cms/schemas/documents/logos.js
+++ b/cms/schemas/documents/logos.js
@@ -18,6 +18,8 @@ export default {
       options: {
         hotspot: true,
       },
+      codegen: { required: true },
+      validation: (Rule) => Rule.required(),
     },
     {
       name: 'hcLogo',

--- a/cms/schemas/documents/navigation.js
+++ b/cms/schemas/documents/navigation.js
@@ -14,6 +14,7 @@ export default {
       title: 'Name',
       type: 'string',
       validation: (Rule) => Rule.required().error('Missing name'),
+      codegen: { required: true },
     },
     {
       name: 'items',

--- a/cms/schemas/documents/page.js
+++ b/cms/schemas/documents/page.js
@@ -36,8 +36,9 @@ export default {
                 .replace(/^-+/, '')
                 .replace(/-+$/, ''),
       },
+      codegen: { required: true },
       validation: (Rule) => [
-        Rule.required().error('Missing slug'),
+        Rule.required(),
         Rule.custom((slug) => {
           if (slug.current.startsWith('/')) {
             return true

--- a/cms/schemas/objects/companyHistory.js
+++ b/cms/schemas/objects/companyHistory.js
@@ -8,6 +8,8 @@ export default {
       title: 'Title',
       type: 'string',
       initialValue: 'Company History',
+      validation: (Rule) => Rule.required(),
+      codegen: { required: true },
     },
     {
       name: 'history',

--- a/cms/schemas/objects/link.js
+++ b/cms/schemas/objects/link.js
@@ -1,5 +1,4 @@
 const customValidation = (field, context, value) => {
-  console.log(context)
   return context.parent.itemType === value && field === undefined
 }
 

--- a/cms/schemas/objects/link.js
+++ b/cms/schemas/objects/link.js
@@ -1,3 +1,8 @@
+const customValidation = (field, context, value) => {
+  console.log(context)
+  return context.parent.itemType === value && field === undefined
+}
+
 export default {
   name: 'link',
   type: 'object',
@@ -26,7 +31,6 @@ export default {
         list: [
           { title: 'Internal Link', value: 'internal' },
           { title: 'External Link', value: 'external' },
-          { title: 'Placeholder', value: 'placeholder' },
         ],
         layout: 'radio',
         direction: 'horizontal',

--- a/cms/schemas/objects/navItem.js
+++ b/cms/schemas/objects/navItem.js
@@ -13,7 +13,6 @@ export default {
       name: 'text',
       type: 'string',
       title: 'Navigation Text',
-      validation: (Rule) => Rule.required(),
     },
     {
       name: 'navigationItemUrl',

--- a/cms/schemas/objects/services.js
+++ b/cms/schemas/objects/services.js
@@ -1,0 +1,53 @@
+export default {
+  name: 'services',
+  title: 'Services',
+  type: 'object',
+  fields: [
+    {
+      name: 'title',
+      title: 'Title',
+      type: 'string',
+      codegen: { required: true },
+      validation: (Rule) => Rule.required(),
+    },
+    {
+      name: 'services',
+      title: 'Services',
+      type: 'array',
+      of: [
+        {
+          name: 'service',
+          title: 'Service',
+          type: 'object',
+          fields: [
+            {
+              name: 'title',
+              title: 'Title',
+              type: 'string',
+              codegen: { required: true },
+              validation: (Rule) => Rule.required(),
+            },
+            {
+              name: 'description',
+              title: 'Description',
+              type: 'blockContent',
+            },
+            {
+              name: 'image',
+              title: 'Image',
+              type: 'image',
+              option: {
+                hotspot: true,
+              },
+            },
+            {
+              name: 'link',
+              title: 'Link',
+              type: 'link',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}

--- a/cms/schemas/schema.js
+++ b/cms/schemas/schema.js
@@ -19,6 +19,7 @@ import link from './objects/link'
 import frontHero from './objects/frontHero'
 import blockContent from './objects/blockContent'
 import companyHistory from './objects/companyHistory'
+import services from './objects/services'
 
 // Then we give our schema to the builder and provide the result to Sanity
 export default createSchema({
@@ -42,5 +43,6 @@ export default createSchema({
     link,
     frontHero,
     blockContent,
+    services,
   ]),
 })

--- a/cms/yarn.lock
+++ b/cms/yarn.lock
@@ -1458,6 +1458,21 @@
     object-assign "^4.1.1"
     rxjs "^6.0.0"
 
+"@sanity/code-input@^2.30.0":
+  version "2.36.0"
+  resolved "https://registry.yarnpkg.com/@sanity/code-input/-/code-input-2.36.0.tgz#9bf850854e65c2026cf2613a87e47766195b7195"
+  integrity sha512-QHoCEvXHrVzuoCWi0gwQh5qFnZq+j9fNUwlx4JnHyf1S/bZgaQt/ZUSFajkjyhuNlIDrZ9DQNF0xIdNUnCjDCA==
+  dependencies:
+    "@reach/auto-id" "^0.13.2"
+    "@sanity/base" "2.35.2"
+    "@sanity/form-builder" "2.35.2"
+    "@sanity/icons" "^1.3.4"
+    "@sanity/types" "2.35.0"
+    "@sanity/ui" "^0.37.22"
+    "@sanity/util" "2.35.0"
+    ace-builds "^1.4.13"
+    react-ace "^9.5.0"
+
 "@sanity/color@^2.1.11", "@sanity/color@^2.1.14":
   version "2.1.19"
   resolved "https://registry.npmjs.org/@sanity/color/-/color-2.1.19.tgz#ec5ad6ceb437b732a390575a079eb94c09ef2d2a"
@@ -2320,6 +2335,11 @@ accepts@~1.3.8:
   dependencies:
     mime-types "~2.1.34"
     negotiator "0.6.3"
+
+ace-builds@^1.4.13:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.13.2.tgz#119190713a14df6882fcd44327585aa8664900e6"
+  integrity sha512-klCL3cp2YXNZ71B5oqYwddwFShdXPRybpPHog38NCUpVKv8b31CdQfs4E6Fap8WSP8ETZPZCN4Z4+yuB5LZAuA==
 
 acorn-dynamic-import@^2.0.0:
   version "2.0.2"
@@ -6808,6 +6828,11 @@ lodash.foreach@^3.0.3:
     lodash._bindcallback "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -6817,6 +6842,11 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
   integrity sha512-JwObCrNJuT0Nnbuecmqr5DgtuBppuCvGD9lxjFpAzwnVtdGoDQ1zig+5W8k5/6Gcn0gZ3936HDAlGd28i7sOGQ==
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
 
 lodash.isplainobject@^4.0.0, lodash.isplainobject@^4.0.6:
   version "4.0.6"
@@ -8881,6 +8911,17 @@ raw-body@2.5.1:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+react-ace@^9.5.0:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-9.5.0.tgz#b6c32b70d404dd821a7e01accc2d76da667ff1f7"
+  integrity sha512-4l5FgwGh6K7A0yWVMQlPIXDItM4Q9zzXRqOae8KkCl6MkOob7sC1CzHxZdOGvV+QioKWbX2p5HcdOVUv6cAdSg==
+  dependencies:
+    ace-builds "^1.4.13"
+    diff-match-patch "^1.0.5"
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.5.0"
+    prop-types "^15.7.2"
 
 react-base16-styling@^0.6.0:
   version "0.6.0"

--- a/web/components/common/Footer.tsx
+++ b/web/components/common/Footer.tsx
@@ -6,9 +6,9 @@ import NLink from 'next/link'
 import Form from '@common/Form'
 import Title from '@common/Title'
 
-const Section = tw.footer`w-full bg-font py-12 flex flex-col px-12`
-const Top = tw.div`flex flex-row  mb-12`
-const Half = tw.div`flex flex-col w-1/2 items-center justify-between text-white`
+const Section = tw.footer`w-full bg-font py-12 flex flex-col px-4 md:px-12`
+const Top = tw.div`flex flex-col lg:(flex-row  gap-12) gap-20 mb-12`
+const Half = tw.div`flex flex-col w-full lg:w-1/2 items-center justify-between text-white`
 const Copyright = tw.small`text-sm text-white flex gap-1`
 const Link = tw(NLink)`duration-500 ease-in-out hover:text-primary`
 
@@ -30,11 +30,10 @@ interface Props {
 }
 
 const Footer: FC<Props> = ({ address, mapsLink, mapsEmbed, ...rest }) => {
-  console.log(mapsEmbed)
   return (
     <Section {...rest}>
       <Top>
-        <Half tw="gap-6">
+        <Half tw="gap-12 lg:gap-6">
           <Title white>Address</Title>
           <Address>
             {address?.map((line, i) => (

--- a/web/components/common/Footer.tsx
+++ b/web/components/common/Footer.tsx
@@ -1,4 +1,4 @@
-import type { VFC } from 'react'
+import type { FC } from 'react'
 import tw from 'twin.macro'
 import styled from 'styled-components'
 import NLink from 'next/link'
@@ -16,26 +16,37 @@ const Address = tw.address`not-italic text-center text-2xl gap-1 flex flex-col`
 const Map = styled.div`
   ${tw`border-2 w-full max-w-[30rem] aspect-[4/3] border-offBlack [iframe]:(w-full h-full)`}
 `
-// const Shadow = tw.div`absolute top-0 left-0 w-full h-full from-primary to-offBlack bg-gradient-to-br z-10 opacity-0 duration-500 ease-in-out`
-interface Props {}
+const Directions = tw.a`text-2xl text-center duration-500 ease-in-out hover:text-primary`
+interface Props {
+  address: string[] | undefined
+  mapsLink: string | undefined
+  mapsEmbed:
+    | {
+        _type: string
+        code: string
+        language: string
+      }
+    | undefined
+}
 
-const Footer: VFC<Props> = ({ ...rest }) => {
+const Footer: FC<Props> = ({ address, mapsLink, mapsEmbed, ...rest }) => {
+  console.log(mapsEmbed)
   return (
     <Section {...rest}>
       <Top>
         <Half tw="gap-6">
           <Title white>Address</Title>
           <Address>
-            <span>Gateway Travel Plaza</span>
-            <span>11653 Lincoln Highway</span>
-            <span>Breezewood, PA 15533</span>
+            {address?.map((line, i) => (
+              <span key={i}>{line}</span>
+            ))}
           </Address>
-          <Map>
-            <iframe
-              src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3056.3675861545303!2d-78.23662282353231!3d40.00023608088264!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89ca34f0c91e2b1d%3A0xc6e6c40a8072f73d!2sGateway%20Travel%20Plaza!5e0!3m2!1sen!2sus!4v1670198522432!5m2!1sen!2sus"
-              loading="lazy"
-            ></iframe>
-          </Map>
+          {!!mapsLink && !mapsEmbed && (
+            <Directions href={mapsLink}>Map + Directions</Directions>
+          )}
+          {!!mapsEmbed && (
+            <Map dangerouslySetInnerHTML={{ __html: mapsEmbed.code }} />
+          )}
         </Half>
         <Half>
           <div tw="w-full flex flex-col items-center gap-12 max-w-[30rem]">

--- a/web/components/common/Header.tsx
+++ b/web/components/common/Header.tsx
@@ -13,13 +13,13 @@ import { cleanPhoneNumber } from '@functions'
 const Component = styled.header<{ small: boolean }>(({ small }) => [
   tw`border-offBlack h-[5rem] border-opacity-30 fixed top-0 left-0 flex z-excessive flex-row items-center justify-between w-full gap-4 px-4 py-2 duration-300 ease-in-out bg-white text-font border-b shadow-xl`,
   !!small
-    ? tw`xl:(h-24 bg-opacity-100)`
-    : tw`xl:(h-36 bg-opacity-0 border-transparent shadow-none text-white)`,
+    ? tw`lg:(h-24 bg-opacity-100)`
+    : tw`lg:(h-36 bg-opacity-0 border-transparent shadow-none text-white)`,
 ])
 
-const Number = tw.a`text-xl font-poppins hover:text-primary`
+const Number = tw.a`text-xl font-poppins hover:text-primary font-semibold`
 const LogoWrapper = styled(Link)`
-  ${tw`flex items-center justify-center w-56 h-full`}
+  ${tw`lg:w-56 w-36 flex items-center justify-center h-full`}
 `
 const NavButton = tw.button`md:hidden flex flex-col shadow-xl justify-center items-center h-16 w-16 border-2 border-offBlack rounded-lg bg-offBlack font-bold text-xs text-white px-3 hover:(text-offBlack bg-white [div]:bg-offBlack) duration-500 ease-in-out`
 

--- a/web/components/common/Header.tsx
+++ b/web/components/common/Header.tsx
@@ -4,6 +4,7 @@ import tw from 'twin.macro'
 import styled from 'styled-components'
 import Link from 'next/link'
 
+import type { Logos as LogosType } from 'lib/schema'
 import DesktopNav from '@common/DesktopNav'
 import MobileNav from '@common/MobileNav'
 import Logo from '@common/Logo'
@@ -24,7 +25,6 @@ const NavButton = tw.button`md:hidden flex flex-col shadow-xl justify-center ite
 
 const Line = tw.div`flex bg-white h-0.5 w-full duration-500 ease-in-out my-[3px] [&:nth-child(2)]:(translate-x-1)`
 
-const phoneNumber = '(555) 555-5555'
 const navItems = [
   {
     title: 'History',
@@ -73,10 +73,11 @@ const navItems = [
 ]
 
 interface FilterProps {
-  logos: any
+  logos: LogosType
+  phoneNumber: string | undefined
 }
 
-const Header: FC<FilterProps> = ({ logos, ...rest }) => {
+const Header: FC<FilterProps> = ({ logos, phoneNumber, ...rest }) => {
   const [smallHeader, setSmallHeader] = useState<boolean>(false)
   const [menuOpen, setMenuOpen] = useState<boolean>(false)
   const { logo, hcLogo } = logos
@@ -98,13 +99,15 @@ const Header: FC<FilterProps> = ({ logos, ...rest }) => {
   return (
     <Component {...rest} small={smallHeader}>
       <LogoWrapper href="/">
-        <Logo logo={logo} hcLogo={hcLogo} />
+        <Logo logo={logo} hcLogo={hcLogo} header useHC={smallHeader} />
       </LogoWrapper>
       <div tw="hidden md:flex flex-col items-end gap-2">
         <DesktopNav navItems={navItems} />
-        <Number href={`tel:${cleanPhoneNumber(phoneNumber)}`}>
-          {phoneNumber}
-        </Number>
+        {!!phoneNumber && (
+          <Number href={`tel:${cleanPhoneNumber(phoneNumber)}`}>
+            {phoneNumber}
+          </Number>
+        )}
       </div>
       <NavButton onClick={() => setMenuOpen(!menuOpen)}>
         <Line />

--- a/web/components/common/Layout.tsx
+++ b/web/components/common/Layout.tsx
@@ -1,20 +1,26 @@
 import type { FC, ReactNode } from 'react'
 import tw from 'twin.macro'
 
+import type {
+  CompanyInfo as CompanyInfoType,
+  Logos as LogosType,
+} from 'lib/schema'
 import Header from '@common/Header'
 import Footer from '@common/Footer'
 
 interface LayoutProps {
   children: ReactNode
-  logos: any
+  logos: LogosType
+  companyInfo: CompanyInfoType
 }
 
-const Layout: FC<LayoutProps> = ({ logos, children }) => {
+const Layout: FC<LayoutProps> = ({ logos, companyInfo, children }) => {
+  const { address, email, phoneNumber, mapsEmbed, mapsLink } = companyInfo
   return (
     <>
-      <Header logos={logos} />
+      <Header logos={logos} phoneNumber={phoneNumber} />
       <main>{children}</main>
-      <Footer />
+      <Footer address={address} mapsLink={mapsLink} mapsEmbed={mapsEmbed} />
     </>
   )
 }

--- a/web/components/common/Logo.tsx
+++ b/web/components/common/Logo.tsx
@@ -1,11 +1,7 @@
-import type { FC, ReactNode } from 'react'
+import type { FC } from 'react'
 import tw from 'twin.macro'
-import groq from 'groq'
 
-import { configuredSanityClient } from '@functions'
 import Image from '@common/SanityImage'
-
-const Section = tw.section``
 
 interface LogoProps {
   logo?: any

--- a/web/components/common/Logo.tsx
+++ b/web/components/common/Logo.tsx
@@ -8,11 +8,12 @@ const HeaderWrapper = tw.div`flex flex-row gap-4 relative h-full w-full`
 const HeaderImage = styled(Image)(
   ({ hc = false, useHC }: { hc?: boolean; useHC: boolean }) => [
     tw`absolute object-contain h-full duration-300 ease-in-out`,
+    hc ? tw`opacity-100` : tw`opacity-0`,
     useHC && hc
-      ? tw`opacity-100`
+      ? tw`lg:opacity-100`
       : !hc && !useHC
-      ? tw`opacity-100`
-      : tw`opacity-0`,
+      ? tw`lg:opacity-100`
+      : tw`lg:opacity-0`,
   ]
 )
 interface LogoProps {

--- a/web/components/common/Logo.tsx
+++ b/web/components/common/Logo.tsx
@@ -1,15 +1,42 @@
 import type { FC } from 'react'
 import tw from 'twin.macro'
+import styled from 'styled-components'
 
 import Image from '@common/SanityImage'
 
+const HeaderWrapper = tw.div`flex flex-row gap-4 relative h-full w-full`
+const HeaderImage = styled(Image)(
+  ({ hc = false, useHC }: { hc?: boolean; useHC: boolean }) => [
+    tw`absolute object-contain h-full duration-300 ease-in-out`,
+    useHC && hc
+      ? tw`opacity-100`
+      : !hc && !useHC
+      ? tw`opacity-100`
+      : tw`opacity-0`,
+  ]
+)
 interface LogoProps {
   logo?: any
   hcLogo?: any
+  header?: boolean
+  useHC?: boolean
 }
 
-const Logo: FC<LogoProps> = ({ logo, hcLogo, ...rest }) => {
-  return <Image image={hcLogo} {...rest}></Image>
+const Logo: FC<LogoProps> = ({
+  logo,
+  hcLogo,
+  header = false,
+  useHC = false,
+  ...rest
+}) => {
+  return header ? (
+    <HeaderWrapper>
+      <HeaderImage image={logo} useHC={useHC} {...rest}></HeaderImage>
+      <HeaderImage image={hcLogo} hc useHC={useHC} {...rest}></HeaderImage>
+    </HeaderWrapper>
+  ) : (
+    <Image image={useHC ? hcLogo : logo} {...rest}></Image>
+  )
 }
 
 export default Logo

--- a/web/components/common/Title.tsx
+++ b/web/components/common/Title.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { useInView } from 'react-intersection-observer'
 
 const styles = ({ white, inView }: { white: boolean; inView: boolean }) => [
-  tw`text-7xl font-allita relative flex flex-col items-center text-center pb-4 after:([content: ""] bg-primary h-1 absolute duration-700 ease-in-out bottom-0 )`,
+  tw`text-6xl sm:text-7xl font-allita relative flex flex-col items-center text-center pb-4 after:([content: ""] bg-primary h-1 absolute duration-700 ease-in-out bottom-0 )`,
   !!white ? tw`text-white` : tw`text-font`,
   !!inView ? tw`after:(w-3/4)` : tw`after:(w-0)`,
 ]

--- a/web/components/frontPage/CompanyHistory.tsx
+++ b/web/components/frontPage/CompanyHistory.tsx
@@ -7,9 +7,9 @@ import Content from '@common/Content'
 import AnimateIn from '@common/AnimateIn'
 import type { CompanyHistory as CompanyHistoryType } from 'lib/schema'
 
-const Section = tw.section`flex flex-col items-center relative w-full py-20 gap-20`
-const Bottom = tw.div`flex w-full px-12 gap-12 relative`
-const Half = tw.div`flex flex-col justify-center w-1/2`
+const Section = tw.section`flex bg-offWhite flex-col items-center relative w-full py-20 gap-20`
+const Bottom = tw.div`flex flex-col lg:flex-row w-full px-4 md:px-12 gap-12 relative`
+const Half = tw.div`flex flex-col justify-center w-full lg:w-1/2`
 
 const CompanyHistory: FC<CompanyHistoryType> = ({
   history,

--- a/web/components/frontPage/FrontHero.tsx
+++ b/web/components/frontPage/FrontHero.tsx
@@ -3,7 +3,7 @@ import tw from 'twin.macro'
 import Image from '@common/SanityImage'
 import { FrontHero as FrontHeroType } from 'lib/schema'
 
-const Section = tw.section`w-full max-w-full h-screen text-white font-bold text-4xl flex flex-col relative items-center justify-center overflow-hidden`
+const Section = tw.section`w-full max-w-full h-screen text-white font-bold text-4xl flex flex-col relative items-center justify-center overflow-hidden text-center`
 
 const FrontHero: FC<FrontHeroType> = ({
   title,
@@ -16,7 +16,7 @@ const FrontHero: FC<FrontHeroType> = ({
       <Image
         image={background}
         alt="hero image"
-        tw="object-cover brightness-[25%] absolute z-behind"
+        tw="object-cover brightness-[25%] absolute h-full w-full z-behind"
       />
       <h1 tw="text-7xl">{title}</h1>
       <h3 tw="text-4xl text-primary mt-2">{subtitle}</h3>

--- a/web/components/frontPage/FrontHero.tsx
+++ b/web/components/frontPage/FrontHero.tsx
@@ -16,7 +16,7 @@ const FrontHero: FC<FrontHeroType> = ({
       <Image
         image={background}
         alt="hero image"
-        tw="object-cover brightness-[25%] absolute h-full w-full z-behind"
+        tw="object-cover brightness-[40%] absolute h-full w-full z-behind"
       />
       <h1 tw="text-7xl">{title}</h1>
       <h3 tw="text-4xl text-primary mt-2">{subtitle}</h3>

--- a/web/components/frontPage/FrontHero.tsx
+++ b/web/components/frontPage/FrontHero.tsx
@@ -3,7 +3,7 @@ import tw from 'twin.macro'
 import Image from '@common/SanityImage'
 import { FrontHero as FrontHeroType } from 'lib/schema'
 
-const Section = tw.section`w-full max-w-full h-screen text-white font-bold text-4xl flex flex-col items-center justify-center overflow-hidden`
+const Section = tw.section`w-full max-w-full h-screen text-white font-bold text-4xl flex flex-col relative items-center justify-center overflow-hidden`
 
 const FrontHero: FC<FrontHeroType> = ({
   title,

--- a/web/components/frontPage/ServiceItem.tsx
+++ b/web/components/frontPage/ServiceItem.tsx
@@ -1,0 +1,44 @@
+import type { FC, ReactNode } from 'react'
+import tw from 'twin.macro'
+import styled from 'styled-components'
+
+import { Services as ServicesType } from 'lib/schema'
+import Image from '@common/SanityImage'
+import Content from '@common/Content'
+
+const Item = styled.div(({ flip }: { flip: boolean }) => [
+  tw`flex w-full border border-red-500`,
+  flip ? tw`flex-row-reverse` : tw`flex-row`,
+])
+const ContentWrapper = tw.div`flex flex-col w-1/2 p-12 gap-4`
+
+interface ServiceItemProps {
+  flip: boolean
+  title: string
+  link?: any
+  image?: any
+  description?: any
+}
+
+const ServiceItem: FC<ServiceItemProps> = ({
+  flip,
+  title,
+  link,
+  image,
+  description,
+  ...rest
+}) => {
+  console.log(image)
+  return (
+    <Item flip={flip} {...rest}>
+      {/* {!!image && <Image {...image} />} */}
+      <ContentWrapper>
+        <h3>{title}</h3>
+        <p>{link?.text}</p>
+        <Content content={description} />
+      </ContentWrapper>
+    </Item>
+  )
+}
+
+export default ServiceItem

--- a/web/components/frontPage/ServiceItem.tsx
+++ b/web/components/frontPage/ServiceItem.tsx
@@ -28,7 +28,6 @@ const ServiceItem: FC<ServiceItemProps> = ({
   description,
   ...rest
 }) => {
-  console.log(image)
   return (
     <Item flip={flip} {...rest}>
       {/* {!!image && <Image {...image} />} */}

--- a/web/components/frontPage/ServiceItem.tsx
+++ b/web/components/frontPage/ServiceItem.tsx
@@ -1,23 +1,21 @@
 import type { FC, ReactNode } from 'react'
 import tw from 'twin.macro'
 import styled from 'styled-components'
-import sanityClient from 'lib/sanity-client'
-import { Services as ServicesType } from 'lib/schema'
 
 import Image from '@common/SanityImage'
 import Content from '@common/Content'
 import AnimateIn from '@common/AnimateIn'
 
 const Item = styled.div(({ flip }: { flip: boolean }) => [
-  tw`flex`,
-  flip ? tw`flex-row-reverse` : tw`flex-row`,
+  tw`lg:items-stretch flex flex-col items-center`,
+  flip ? tw`md:flex-row-reverse` : tw`md:flex-row`,
 ])
 const ContentWrapper = styled.div(({ flip }: { flip: boolean }) => [
-  tw`flex flex-col w-full gap-4 px-12 py-6`,
-  flip ? tw`items-end` : tw`items-start`,
+  tw`md:px-12 flex flex-col w-full gap-4 py-6 items-start`,
+  flip ? tw`md:(items-end text-right)` : tw``,
 ])
 
-const Title = tw.span`text-4xl font-poppins`
+const Title = tw.span`text-4xl font-poppins relative pb-2 after:([content: ''] bg-primary w-full h-1 bottom-0 left-0 absolute)`
 
 interface ServiceItemProps {
   flip: boolean
@@ -35,6 +33,7 @@ const ServiceItem: FC<ServiceItemProps> = ({
   description,
   ...rest
 }) => {
+  !!image && console.log(image)
   return (
     <AnimateIn
       direction={flip ? 'left' : 'right'}
@@ -42,9 +41,14 @@ const ServiceItem: FC<ServiceItemProps> = ({
       duration={1000}
     >
       <Item flip={flip} {...rest}>
-        {/* {image?._type === 'image' && <Image {...image} />} */}
+        {!!image && (
+          <Image
+            image={image}
+            tw="md:max-w-[15rem] lg:max-w-[20rem] object-cover shadow-xl"
+          />
+        )}
         {/* remove this when image works*/}
-        <div tw="bg-primary max-w-[15rem] w-full"></div>
+        {/* <div tw="bg-primary max-w-[15rem] w-full"></div> */}
         <ContentWrapper flip={flip}>
           <Title>{title}</Title>
           <Content content={description} />

--- a/web/components/frontPage/ServiceItem.tsx
+++ b/web/components/frontPage/ServiceItem.tsx
@@ -1,16 +1,23 @@
 import type { FC, ReactNode } from 'react'
 import tw from 'twin.macro'
 import styled from 'styled-components'
-
+import sanityClient from 'lib/sanity-client'
 import { Services as ServicesType } from 'lib/schema'
+
 import Image from '@common/SanityImage'
 import Content from '@common/Content'
+import AnimateIn from '@common/AnimateIn'
 
 const Item = styled.div(({ flip }: { flip: boolean }) => [
-  tw`flex w-full border border-red-500`,
+  tw`flex`,
   flip ? tw`flex-row-reverse` : tw`flex-row`,
 ])
-const ContentWrapper = tw.div`flex flex-col w-1/2 p-12 gap-4`
+const ContentWrapper = styled.div(({ flip }: { flip: boolean }) => [
+  tw`flex flex-col w-full gap-4 px-12 py-6`,
+  flip ? tw`items-end` : tw`items-start`,
+])
+
+const Title = tw.span`text-4xl font-poppins`
 
 interface ServiceItemProps {
   flip: boolean
@@ -29,14 +36,21 @@ const ServiceItem: FC<ServiceItemProps> = ({
   ...rest
 }) => {
   return (
-    <Item flip={flip} {...rest}>
-      {/* {!!image && <Image {...image} />} */}
-      <ContentWrapper>
-        <h3>{title}</h3>
-        <p>{link?.text}</p>
-        <Content content={description} />
-      </ContentWrapper>
-    </Item>
+    <AnimateIn
+      direction={flip ? 'left' : 'right'}
+      distance="50px"
+      duration={1000}
+    >
+      <Item flip={flip} {...rest}>
+        {/* {image?._type === 'image' && <Image {...image} />} */}
+        {/* remove this when image works*/}
+        <div tw="bg-primary max-w-[15rem] w-full"></div>
+        <ContentWrapper flip={flip}>
+          <Title>{title}</Title>
+          <Content content={description} />
+        </ContentWrapper>
+      </Item>
+    </AnimateIn>
   )
 }
 

--- a/web/components/frontPage/Services.tsx
+++ b/web/components/frontPage/Services.tsx
@@ -6,7 +6,7 @@ import { Services as ServicesType } from 'lib/schema'
 import Title from '@common/Title'
 import Item from '@frontPage/ServiceItem'
 
-const Section = tw.section`flex flex-col items-center w-full bg-offWhite relative py-20 px-32 gap-12`
+const Section = tw.section`flex flex-col items-center w-full bg-offWhite relative py-20 px-12 xl:px-32 gap-12`
 const List = tw.ul`flex flex-col items-center w-full gap-20 relative`
 const ItemWrapper = styled.li(({ flip }: { flip: boolean }) => [
   tw`flex flex-col w-full max-w-[60rem]`,

--- a/web/components/frontPage/Services.tsx
+++ b/web/components/frontPage/Services.tsx
@@ -1,0 +1,28 @@
+import type { FC, ReactNode } from 'react'
+import tw from 'twin.macro'
+
+import Title from '@common/Title'
+
+const Section = tw.section`flex flex-col items-center w-full relative py-20 border border-red-500 px-32 gap-12`
+
+interface ServicesProps {
+  title: string
+}
+
+const Services: FC<ServicesProps> = ({ title, ...rest }) => {
+  const services = [{}, {}, {}, {}, {}, {}, {}, {}, {}]
+  return (
+    <Section {...rest}>
+      <Title>{title}</Title>
+      <div tw="grid grid-cols-3 gap-8 w-full">
+        {services.map((service, index) => (
+          <div key={index} tw="border border-red-500 h-[10rem]">
+            <h1>Service {index + 1}</h1>
+          </div>
+        ))}
+      </div>
+    </Section>
+  )
+}
+
+export default Services

--- a/web/components/frontPage/Services.tsx
+++ b/web/components/frontPage/Services.tsx
@@ -1,26 +1,24 @@
 import type { FC, ReactNode } from 'react'
 import tw from 'twin.macro'
+import { Services as ServicesType } from 'lib/schema'
 
 import Title from '@common/Title'
+import Item from '@frontPage/ServiceItem'
 
 const Section = tw.section`flex flex-col items-center w-full relative py-20 border border-red-500 px-32 gap-12`
+const List = tw.ul`flex flex-col w-full gap-20 relative`
 
-interface ServicesProps {
-  title: string
-}
-
-const Services: FC<ServicesProps> = ({ title, ...rest }) => {
-  const services = [{}, {}, {}, {}, {}, {}, {}, {}, {}]
+const Services: FC<ServicesType> = ({ title, services, ...rest }) => {
   return (
     <Section {...rest}>
       <Title>{title}</Title>
-      <div tw="grid grid-cols-3 gap-8 w-full">
-        {services.map((service, index) => (
-          <div key={index} tw="border border-red-500 h-[10rem]">
-            <h1>Service {index + 1}</h1>
-          </div>
+      <List>
+        {services?.map((service, i) => (
+          <li key={i}>
+            <Item flip={!!(i % 2)} {...service} />
+          </li>
         ))}
-      </div>
+      </List>
     </Section>
   )
 }

--- a/web/components/frontPage/Services.tsx
+++ b/web/components/frontPage/Services.tsx
@@ -1,12 +1,17 @@
 import type { FC, ReactNode } from 'react'
 import tw from 'twin.macro'
+import styled from 'styled-components'
 import { Services as ServicesType } from 'lib/schema'
 
 import Title from '@common/Title'
 import Item from '@frontPage/ServiceItem'
 
-const Section = tw.section`flex flex-col items-center w-full relative py-20 border border-red-500 px-32 gap-12`
-const List = tw.ul`flex flex-col w-full gap-20 relative`
+const Section = tw.section`flex flex-col items-center w-full bg-offWhite relative py-20 px-32 gap-12`
+const List = tw.ul`flex flex-col items-center w-full gap-20 relative`
+const ItemWrapper = styled.li(({ flip }: { flip: boolean }) => [
+  tw`flex flex-col w-full max-w-[60rem]`,
+  flip ? tw`self-end` : tw`self-start`,
+])
 
 const Services: FC<ServicesType> = ({ title, services, ...rest }) => {
   return (
@@ -14,9 +19,9 @@ const Services: FC<ServicesType> = ({ title, services, ...rest }) => {
       <Title>{title}</Title>
       <List>
         {services?.map((service, i) => (
-          <li key={i}>
+          <ItemWrapper key={i} flip={!!(i % 2)}>
             <Item flip={!!(i % 2)} {...service} />
-          </li>
+          </ItemWrapper>
         ))}
       </List>
     </Section>

--- a/web/lib/sanity-client.ts
+++ b/web/lib/sanity-client.ts
@@ -1,9 +1,10 @@
-import { createClient } from 'sanity-codegen';
-import { Documents } from './schema';
+import { createClient as createCodegenClient } from 'sanity-codegen'
+import { createClient as createDefaultClient } from 'next-sanity'
+import { Documents } from './schema'
 
 // This type parameter enables the client to be aware of your generated types
 //                           👇👇👇
-export default createClient<Documents>({
+export default createCodegenClient<Documents>({
   // Note: these are useful to pull from environment variables
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID ?? '',
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET ?? '',
@@ -16,4 +17,9 @@ export default createClient<Documents>({
   // if you plan on using this in browsers. don't use this with preview mode
   // see here: https://www.sanity.io/docs/api-cdn
   // useCdn: true,
-});
+})
+
+export const defaultSanityClient = createDefaultClient({
+  projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID ?? '',
+  dataset: process.env.NEXT_PUBLIC_SANITY_DATASET ?? '',
+})

--- a/web/lib/schema.ts
+++ b/web/lib/schema.ts
@@ -240,6 +240,13 @@ export interface CompanyInfo extends SanityDocument {
    *
    */
   mapsLink?: string;
+
+  /**
+   * Maps Embed — `code`
+   *
+   *
+   */
+  mapsEmbed?: Code;
 }
 
 /**
@@ -508,3 +515,10 @@ export type Documents =
   | CompanyInfo
   | HomePage
   | MetaData;
+
+/**
+ * This interface is a stub. It was referenced in your sanity schema but
+ * the definition was not actually found. Future versions of
+ * sanity-codegen will let you type this explicity.
+ */
+type Code = any;

--- a/web/lib/schema.ts
+++ b/web/lib/schema.ts
@@ -56,7 +56,7 @@ export interface Page extends SanityDocument {
    *
    *
    */
-  slug?: { _type: "slug"; current: string };
+  slug: { _type: "slug"; current: string };
 
   /**
    * Parent — `reference`
@@ -105,7 +105,7 @@ export interface Navigation extends SanityDocument {
    *
    *
    */
-  name?: string;
+  name: string;
 
   /**
    * Navigation Items — `array`
@@ -135,7 +135,7 @@ export interface Logos extends SanityDocument {
    *
    *
    */
-  logo?: {
+  logo: {
     _type: "image";
     asset: SanityReference<SanityImageAsset>;
     crop?: SanityImageCrop;
@@ -204,7 +204,7 @@ export interface CompanyInfo extends SanityDocument {
    *
    *
    */
-  name?: string;
+  name: string;
 
   /**
    * Phone Number — `string`
@@ -270,6 +270,13 @@ export interface HomePage extends SanityDocument {
    *
    */
   companyHistory?: CompanyHistory;
+
+  /**
+   * Services — `services`
+   *
+   *
+   */
+  services?: Services;
 }
 
 /**
@@ -309,7 +316,7 @@ export type CompanyHistory = {
    *
    *
    */
-  title?: string;
+  title: string;
 
   /**
    * History — `blockContent`
@@ -407,7 +414,7 @@ export type Link = {
    *
    *
    */
-  itemType?: "internal" | "external" | "placeholder";
+  itemType?: "internal" | "external";
 };
 
 export type FrontHero = {
@@ -440,6 +447,59 @@ export type FrontHero = {
 };
 
 export type BlockContent = Array<SanityKeyed<SanityBlock>>;
+
+export type Services = {
+  _type: "services";
+  /**
+   * Title — `string`
+   *
+   *
+   */
+  title: string;
+
+  /**
+   * Services — `array`
+   *
+   *
+   */
+  services?: Array<
+    SanityKeyed<{
+      _type: "service";
+      /**
+       * Title — `string`
+       *
+       *
+       */
+      title: string;
+
+      /**
+       * Description — `blockContent`
+       *
+       *
+       */
+      description?: BlockContent;
+
+      /**
+       * Image — `image`
+       *
+       *
+       */
+      image?: {
+        _type: "image";
+        asset: SanityReference<SanityImageAsset>;
+        crop?: SanityImageCrop;
+        hotspot?: SanityImageHotspot;
+      };
+
+      /**
+       * Link — `link`
+       *
+       *
+       */
+      link?: Link;
+    }>
+  >;
+};
 
 export type Documents =
   | Page

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
     "eslint-config-next": "13.0.5",
     "groq": "^2.33.2",
     "next": "13.0.5",
+    "next-sanity": "^3.1.3",
     "next-sanity-image": "^5.0.0",
     "react": "18.2.0",
     "react-animate-height": "^3.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@types/styled-components": "^5.1.26",
     "babel-plugin-macros": "^3.1.0",
+    "prettier": "^2.8.1",
     "sanity-codegen": "^0.9.8",
     "tailwindcss": "^3.2.4",
     "twin.macro": "^3.0.1"

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -6,10 +6,11 @@ import CompanyHistory from '@frontPage/CompanyHistory'
 import Services from '@frontPage/Services'
 import sanityClient from 'lib/sanity-client'
 
-const Home: NextPage<Props> = ({ homePage, logos }) => {
+const Home: NextPage<Props> = ({ homePage, logos, companyInfo }) => {
   const { hero, companyHistory, services } = homePage
+
   return (
-    <Layout logos={logos}>
+    <Layout logos={logos} companyInfo={companyInfo}>
       {hero && <FrontHero {...hero} />}
       {services && <Services {...services} />}
       {companyHistory && <CompanyHistory {...companyHistory} />}
@@ -25,11 +26,13 @@ type Props = UnwrapPromise<ReturnType<typeof getStaticProps>>['props']
 export const getStaticProps = async function () {
   const [homePage] = await sanityClient.getAll('homePage')
   const [logos] = await sanityClient.getAll('logos')
+  const [companyInfo] = await sanityClient.getAll('companyInfo')
 
   return {
     props: {
       homePage,
       logos,
+      companyInfo,
     },
   }
 }

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -24,7 +24,7 @@ type UnwrapPromise<T> = T extends Promise<infer U> ? U : T
 type Props = UnwrapPromise<ReturnType<typeof getStaticProps>>['props']
 
 export const getStaticProps = async function () {
-  const [homePage] = await sanityClient.getAll('homePage')
+  let [homePage] = await sanityClient.getAll('homePage')
   const [logos] = await sanityClient.getAll('logos')
   const [companyInfo] = await sanityClient.getAll('companyInfo')
 

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,13 +1,14 @@
 import { NextPage } from 'next'
+import groq from 'groq'
 
 import Layout from '@common/Layout'
 import FrontHero from '@frontPage/FrontHero'
 import CompanyHistory from '@frontPage/CompanyHistory'
 import Services from '@frontPage/Services'
-import sanityClient from 'lib/sanity-client'
+import sanityClient, { defaultSanityClient } from 'lib/sanity-client'
 
-const Home: NextPage<Props> = ({ homePage, logos, companyInfo }) => {
-  const { hero, companyHistory, services } = homePage
+const Home: NextPage<Props> = ({ homePage, logos, companyInfo, services }) => {
+  const { hero, companyHistory } = homePage
 
   return (
     <Layout logos={logos} companyInfo={companyInfo}>
@@ -27,12 +28,29 @@ export const getStaticProps = async function () {
   let [homePage] = await sanityClient.getAll('homePage')
   const [logos] = await sanityClient.getAll('logos')
   const [companyInfo] = await sanityClient.getAll('companyInfo')
+  const x = await defaultSanityClient.fetch(groq`
+    *[_type == "homePage"] {
+      services {
+        title,
+        services[] {
+          title,
+          description,
+          link,
+          image {
+            asset-> 
+          }
+        }    
+      }
+    }
+  `)
+  const services = x[0].services
 
   return {
     props: {
       homePage,
       logos,
       companyInfo,
+      services,
     },
   }
 }

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,20 +1,17 @@
-import tw from 'twin.macro'
-import groq from 'groq'
+import { NextPage } from 'next'
 
-import { configuredSanityClient } from '@functions'
 import Layout from '@common/Layout'
 import FrontHero from '@frontPage/FrontHero'
 import CompanyHistory from '@frontPage/CompanyHistory'
+import Services from '@frontPage/Services'
 import sanityClient from 'lib/sanity-client'
-import { GetStaticProps, NextPage } from 'next'
-
-const Div = tw.div`h-[130vh] w-full bg-pink-300`
 
 const Home: NextPage<Props> = ({ homePage, logos }) => {
-  const { hero, companyHistory } = homePage
+  const { hero, companyHistory, services } = homePage
   return (
     <Layout logos={logos}>
       {hero && <FrontHero {...hero} />}
+      {services && <Services {...services} />}
       {companyHistory && <CompanyHistory {...companyHistory} />}
     </Layout>
   )
@@ -26,12 +23,6 @@ type UnwrapPromise<T> = T extends Promise<infer U> ? U : T
 type Props = UnwrapPromise<ReturnType<typeof getStaticProps>>['props']
 
 export const getStaticProps = async function () {
-  // Is there a better way to type `data` here?
-  // We'd have to somehow eject the type defs from Sanity and
-  // tell the client that's what we expect to be returned.
-  // That's not real type safety, and defeats the purpose of using Typescript at all.
-  // Made this a js file for now, to kick the can down the road and decide if it's worth it.
-
   const [homePage] = await sanityClient.getAll('homePage')
   const [logos] = await sanityClient.getAll('logos')
 

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -7,6 +7,7 @@ module.exports = {
         secondary: '#7E9869',
         grey: '#3D4D4D',
         offBlack: '#163930',
+        offWhite: '#FFFAFA',
         font: '#000000',
       },
       fontFamily: {

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -555,7 +555,7 @@
   resolved "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz"
   integrity sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==
 
-"@sanity/client@^3.4.1":
+"@sanity/client@^3.3.3", "@sanity/client@^3.4.1":
   version "3.4.1"
   resolved "https://registry.npmjs.org/@sanity/client/-/client-3.4.1.tgz"
   integrity sha512-WSvnroCHqboUeyY0nl71vDPKmfurXI0mtqdNDb5u8MW00CAHRyCt1+Sgy39D/g+6R35FYniV31vTSTo3ofim0A==
@@ -566,6 +566,11 @@
     object-assign "^4.1.1"
     rxjs "^6.0.0"
 
+"@sanity/color@^2.1.14":
+  version "2.1.20"
+  resolved "https://registry.yarnpkg.com/@sanity/color/-/color-2.1.20.tgz#48c6ad3e6333d1da2989acbead1a46b4a8c5347a"
+  integrity sha512-dHPgiCMf+lwvQls5uPzorfiq9YuU41AzvifA+ugVHmXvq7JBoofoOPUOmdHUQF0l0shSy0nD3zn52j2I+T2ekg==
+
 "@sanity/eventsource@^4.0.0":
   version "4.0.0"
   resolved "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-4.0.0.tgz"
@@ -574,15 +579,58 @@
     event-source-polyfill "1.0.25"
     eventsource "^2.0.2"
 
+"@sanity/groq-store@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@sanity/groq-store/-/groq-store-1.1.4.tgz#0e94834190857151b03f98654743f3fde22fe21a"
+  integrity sha512-xpUJqeP1sKD1VzzalvOIfodZpKmQTaP2lKFE68wnYDcoqG1+h1dCVTf8cWLX/y9jpvr8lxOwIil8QXeWNUj2Aw==
+  dependencies:
+    "@sanity/types" "^2.35.0"
+    eventsource "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    groq "^2.33.2"
+    groq-js "^1.1.3"
+    mendoza "^2.1.1"
+    simple-get "^4.0.1"
+    split2 "^4.1.0"
+    throttle-debounce "^5.0.0"
+
 "@sanity/image-url@^1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@sanity/image-url/-/image-url-1.0.1.tgz#960d649b2f4396da0adb31cf94503c929495cea0"
   integrity sha512-AdKQ3zMk7WdoNwoJPrAvQhW+kUtBldBX0nHtnGy+rwmgsCQ0rAXasrgH43Fhmsp/yB6piiq+F2d5qEuBFsdQVg==
 
+"@sanity/preview-kit@^1.2.10":
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/@sanity/preview-kit/-/preview-kit-1.2.10.tgz#a8a5faf6365f29fb3534b75d533adc0c0275f63e"
+  integrity sha512-EUPlHHitEdtMk9yqd8k15OZwIowX0HBTHs9OOCGTHLU6S3Nx+sFnytr/kLLt3jMLVuK8fcS/1qLxGW/4JaMdqw==
+  dependencies:
+    "@sanity/groq-store" "^1.1.4"
+    "@types/event-source-polyfill" "^1.0.0"
+    event-source-polyfill "^1.0.31"
+    suspend-react "0.0.8"
+
 "@sanity/timed-out@^4.0.2":
   version "4.0.2"
   resolved "https://registry.npmjs.org/@sanity/timed-out/-/timed-out-4.0.2.tgz"
   integrity sha512-NBDKGj14g9Z+bopIvZcQKWCzJq5JSrdmzRR1CS+iyA3Gm8SnIWBfZa7I3mTg2X6Nu8LQXG0EPKXdOGozLS4i3w==
+
+"@sanity/types@^2.35.0":
+  version "2.35.0"
+  resolved "https://registry.yarnpkg.com/@sanity/types/-/types-2.35.0.tgz#e74aba391885061188f8a045e37b9d1f0806ff38"
+  integrity sha512-hocM0bZVa6ONVjLA50gxRSwIcmsaRPpvhl71MgutHxcnvsGZD55n2LQZb4n7h+J9yEFSkz9lY8HbY8n/bw8tsw==
+  dependencies:
+    "@sanity/client" "^3.3.3"
+    "@sanity/color" "^2.1.14"
+    "@types/react" "^17.0.42"
+    rxjs "^6.5.3"
+
+"@sanity/webhook@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sanity/webhook/-/webhook-2.0.0.tgz#22e5916fd6ea616625b4105a68f2858408de8eee"
+  integrity sha512-KusHeWVy6yW3hcgVHbGx6qVv//bUj3CD9Nr0EOw086+mo/ESrUV21HjOCrNQ+AYqXvJ9H5qhqmMiuc8H5dXUGA==
+  dependencies:
+    base64url "^3.0.1"
+    tslib "^2.3.1"
 
 "@swc/helpers@0.4.14":
   version "0.4.14"
@@ -590,6 +638,11 @@
   integrity sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==
   dependencies:
     tslib "^2.4.0"
+
+"@types/event-source-polyfill@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/event-source-polyfill/-/event-source-polyfill-1.0.0.tgz#f93f13433f750c8ea0e3cfa69c72e3c7393e0585"
+  integrity sha512-b8O8/rg7NIW0iJ8i9MNDBZqPljHA+b7AjC3QFqH3dSyW6vgrl3oBgyIv5dw2fibh5enHHDkkPZG5PHza7U4NRw==
 
 "@types/hoist-non-react-statics@*":
   version "3.3.1"
@@ -635,6 +688,15 @@
   version "18.0.25"
   resolved "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz"
   integrity sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17.0.42":
+  version "17.0.52"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.52.tgz#10d8b907b5c563ac014a541f289ae8eaa9bf2e9b"
+  integrity sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -916,6 +978,11 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+base64url@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
+  integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
 
 big.js@^3.1.3:
   version "3.2.0"
@@ -1571,6 +1638,11 @@ event-source-polyfill@1.0.25:
   resolved "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.25.tgz"
   integrity sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg==
 
+event-source-polyfill@^1.0.31:
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz#45fb0a6fc1375b2ba597361ba4287ffec5bf2e0c"
+  integrity sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==
+
 eventsource@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz"
@@ -1871,6 +1943,11 @@ grapheme-splitter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
+groq-js@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/groq-js/-/groq-js-1.1.3.tgz#dfc587b1c7bae66b8597779b8192dbcf3701a351"
+  integrity sha512-lj+W7/zoMxtYt4G/m6ZUrQqK1jfOM+qjYWJ97P+eXSoVOsh+kQ69UUPXJCqeqraYJBeLXdTwM1e5HYxVWeZQjw==
 
 groq@^2.33.2:
   version "2.33.2"
@@ -2314,6 +2391,11 @@ make-error@^1.3.0:
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
+mendoza@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/mendoza/-/mendoza-2.1.1.tgz#19ad4efc3f424439d895e1f1841818a4e268af55"
+  integrity sha512-8f3Se8HDfobXCsdESXZBSSYcVzIRi+cMIEmz/SR4bjgFEjHJaXzrsBYr+vyrFGEtK5xTpCcU+DiwxWJV6hCuhQ==
+
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
@@ -2387,6 +2469,16 @@ next-sanity-image@^5.0.0:
   integrity sha512-mVnybxCEcy3l4mi/Ob+0RhPw6W1b9RcCNfx4PyUCP67+R/Cs75o0x6UEZ2Xk7Vxg9Ms4YAaEXO7GJ5mF5zL0rQ==
   dependencies:
     "@sanity/image-url" "^1.0.0"
+
+next-sanity@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/next-sanity/-/next-sanity-3.1.3.tgz#c1b8e43e88db1828073fbe9c53e6d3751621dc82"
+  integrity sha512-8JqJ4IP3kBghr+gO40F3fTVIJs4mhPlY65TJ7p/z7zj1WuZPyuXSd5NoJGrEuM+p18cuoX5YQQj24HsEyLo7Sg==
+  dependencies:
+    "@sanity/client" "^3.4.1"
+    "@sanity/preview-kit" "^1.2.10"
+    "@sanity/webhook" "^2.0.0"
+    groq "^2.33.2"
 
 next@13.0.5:
   version "13.0.5"
@@ -2488,7 +2580,7 @@ object.values@^1.1.5, object.values@^1.1.6:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1:
   version "1.4.0"
   resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -2946,7 +3038,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^6.0.0:
+rxjs@^6.0.0, rxjs@^6.5.3:
   version "6.6.7"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -3051,10 +3143,19 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-simple-concat@^1.0.1:
+simple-concat@^1.0.0, simple-concat@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz"
   integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 slash@^3.0.0:
   version "3.0.0"
@@ -3088,6 +3189,11 @@ speedometer@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz"
   integrity sha512-lgxErLl/7A5+vgIIXsh9MbeukOaCb2axgQ+bKCdIE+ibNT4XNYGNCR1qFEGq6F+YDASXK3Fh/c5FgtZchFolxw==
+
+split2@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.1.0.tgz#101907a24370f85bb782f08adaabe4e281ecf809"
+  integrity sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==
 
 string.prototype.matchall@^4.0.8:
   version "4.0.8"
@@ -3187,6 +3293,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+suspend-react@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/suspend-react/-/suspend-react-0.0.8.tgz#b0740c1386b4eb652f17affe4339915ee268bd31"
+  integrity sha512-ZC3r8Hu1y0dIThzsGw0RLZplnX9yXwfItcvaIzJc2VQVi8TGyGDlu92syMB5ulybfvGLHAI5Ghzlk23UBPF8xg==
+
 synckit@^0.8.4:
   version "0.8.4"
   resolved "https://registry.npmjs.org/synckit/-/synckit-0.8.4.tgz"
@@ -3234,6 +3345,11 @@ text-table@^0.2.0:
   resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
+throttle-debounce@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/throttle-debounce/-/throttle-debounce-5.0.0.tgz#a17a4039e82a2ed38a5e7268e4132d6960d41933"
+  integrity sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==
+
 through2@~2.0.3:
   version "2.0.5"
   resolved "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz"
@@ -3277,7 +3393,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.4.0:
+tslib@^2.3.1, tslib@^2.4.0:
   version "2.4.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2761,6 +2761,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.1.tgz#4e1fd11c34e2421bc1da9aea9bd8127cd0a35efc"
+  integrity sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"


### PR DESCRIPTION
- Added services section (and removed pink temp div)
- Added additional export to sanity-client to handle traditional queries (until ryan makes my life difficult again and implements some alternative solution that auto-types and has port and starboard attachments)
- header & footer now pull all their data from sanity (except the menu)
- mobile edits for most components